### PR TITLE
Fixes invalid early out of month/year truth test + ensure month is between 1 and 12

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,7 +168,7 @@ exports.expiry = function expiry(month, year) {
   year = +year;
 
   // incorrect numbers should fail fast
-  if (!(month || year)) return false;
+  if (!month || !year || month > 12) return false;
 
   var date = new Date()
     , now = +date;

--- a/test/creditcard.test.js
+++ b/test/creditcard.test.js
@@ -97,5 +97,9 @@ describe('creditcard#expiry', function () {
     expect(creditcard.expiry('06', '1990')).to.equal(false);
     expect(creditcard.expiry('06', '12')).to.equal(false);
     expect(creditcard.expiry(6, 12)).to.equal(false);
+    expect(creditcard.expiry('99', '2020')).to.equal(false);
+    expect(creditcard.expiry(99, 2020)).to.equal(false);
+    expect(creditcard.expiry(null, '2020')).to.equal(false);
+    expect(creditcard.expiry('6', null)).to.equal(false);
   });
 });


### PR DESCRIPTION
- The month / year early out test was not return false right away if month or year was truthy.
- The months weren't capped at 12, made it possible to enter dates like 99/2020
- Added test cases.
