### PR TITLE
[fix] Check for test credit card numbers before attempting validate a…

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,6 +144,10 @@ exports.format = function format(number) {
  * @api public
  */
 exports.validate = function validate(number) {
+
+  //Test for test numbers before running the algorithm
+  if (exports.testnumbers.indexOf(number) !== -1) return true;
+
   number = (''+ number).replace(/\D/g, '');
 
   var i = number.length

--- a/test/creditcard.test.js
+++ b/test/creditcard.test.js
@@ -30,6 +30,14 @@ describe('creditcard#testnumbers', function () {
   it('should have an array of test numbers', function () {
     expect(creditcard.testnumbers).to.be.a('array');
   });
+
+  creditcard.testnumbers.forEach( function (number) {
+
+    it('should validate the test creditcard number: ' + number, function() {
+      expect(creditcard.validate(number)).to.equal(true);      
+    });
+  });
+
 });
 
 describe('creditcard#format', function () {


### PR DESCRIPTION
The code uses the numbers out of https://www.paypalobjects.com/en_US/vhelp/paypalmanager_help/credit_card_numbers.htm, but some of them do not pass the validation.

1. I added in a unit test to test each test credit card against the validator.
2. I added a simple check in the validator to look for a test card first before running an algorithm.

References https://github.com/observing/creditcard/issues/3